### PR TITLE
Proposal: Make AppDevRouter typesafe by forcing people to define what the route will return

### DIFF
--- a/src/routers/Courses/AddAdminsToCourseRouter.js
+++ b/src/routers/Courses/AddAdminsToCourseRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import CoursesRepo from '../../repos/CoursesRepo';
 import constants from '../../utils/constants';
 
-class AddAdminsToCourseRouter extends AppDevRouter {
+class AddAdminsToCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/Courses/AddStudentsToCourseRouter.js
+++ b/src/routers/Courses/AddStudentsToCourseRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import CoursesRepo from '../../repos/CoursesRepo';
 import constants from '../../utils/constants';
 
-class AddStudentsToCourseRouter extends AppDevRouter {
+class AddStudentsToCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/Courses/DeleteCourseRouter.js
+++ b/src/routers/Courses/DeleteCourseRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import CoursesRepo from '../../repos/CoursesRepo';
 import constants from '../../utils/constants';
 
-class DeleteCourseRouter extends AppDevRouter {
+class DeleteCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.DELETE);
   }

--- a/src/routers/Courses/PostCourseRouter.js
+++ b/src/routers/Courses/PostCourseRouter.js
@@ -6,7 +6,7 @@ import constants from '../../utils/constants';
 
 import type { APICourse } from '../APITypes';
 
-class PostCourseRouter extends AppDevRouter {
+class PostCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }
@@ -32,7 +32,7 @@ class PostCourseRouter extends AppDevRouter {
         id: course.id,
         term: course.term,
         name: course.name,
-        code: course.code,
+        code: course.code
       }
     };
   }

--- a/src/routers/Courses/RemoveAdminsFromCourseRouter.js
+++ b/src/routers/Courses/RemoveAdminsFromCourseRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import CoursesRepo from '../../repos/CoursesRepo';
 import constants from '../../utils/constants';
 
-class RemoveAdminsFromCourseRouter extends AppDevRouter {
+class RemoveAdminsFromCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.DELETE);
   }

--- a/src/routers/Courses/RemoveStudentsFromCourseRouter.js
+++ b/src/routers/Courses/RemoveStudentsFromCourseRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import CoursesRepo from '../../repos/CoursesRepo';
 import constants from '../../utils/constants';
 
-class RemoveStudentsFromCourseRouter extends AppDevRouter {
+class RemoveStudentsFromCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.DELETE);
   }

--- a/src/routers/Courses/UpdateCourseRouter.js
+++ b/src/routers/Courses/UpdateCourseRouter.js
@@ -6,7 +6,7 @@ import constants from '../../utils/constants';
 
 import type { APICourse } from '../APITypes';
 
-class UpdateCourseRouter extends AppDevRouter {
+class UpdateCourseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.PUT);
   }

--- a/src/routers/EndLectureRouter.js
+++ b/src/routers/EndLectureRouter.js
@@ -6,7 +6,7 @@ import LecturesRepo from '../repos/LecturesRepo';
 import { Request } from 'express';
 import socket from 'socket.io';
 
-class EndLectureRouter extends AppDevRouter {
+class EndLectureRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }
@@ -16,11 +16,11 @@ class EndLectureRouter extends AppDevRouter {
   }
 
   async content (req: Request) {
-    const id = req.params.id
-    const lecture = await LecturesRepo.getLectureById(id)
+    const id = req.params.id;
+    const lecture = await LecturesRepo.getLectureById(id);
 
     if (!lecture) {
-      throw new Error(`No lecture with id ${id} found.`)
+      throw new Error(`No lecture with id ${id} found.`);
     }
 
     LectureManager.endLecture(lecture);

--- a/src/routers/GetMeRouter.js
+++ b/src/routers/GetMeRouter.js
@@ -7,7 +7,7 @@ import constants from '../utils/constants';
 
 import appDevUtils from '../utils/appDevUtils';
 
-class GetMeRouter extends AppDevRouter {
+class GetMeRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.GET);
   }

--- a/src/routers/GoogleSignInRouter.js
+++ b/src/routers/GoogleSignInRouter.js
@@ -5,7 +5,7 @@ import AppDevRouter from '../utils/AppDevRouter';
 import appDevUtils from '../utils/appDevUtils';
 import constants from '../utils/constants';
 
-class GoogleSignInRouter extends AppDevRouter {
+class GoogleSignInRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/HelloWorldRouter.js
+++ b/src/routers/HelloWorldRouter.js
@@ -3,7 +3,7 @@ import { Request } from 'express';
 import AppDevRouter from '../utils/AppDevRouter';
 import constants from '../utils/constants';
 
-class HelloWorldRouter extends AppDevRouter {
+class HelloWorldRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.GET);
   }

--- a/src/routers/Lectures/DeleteLectureRouter.js
+++ b/src/routers/Lectures/DeleteLectureRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import LecturesRepo from '../../repos/LecturesRepo';
 import constants from '../../utils/constants';
 
-class DeleteLectureRouter extends AppDevRouter {
+class DeleteLectureRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.DELETE);
   }

--- a/src/routers/Lectures/GetLiveLecturesRouter.js
+++ b/src/routers/Lectures/GetLiveLecturesRouter.js
@@ -6,7 +6,7 @@ import UsersRepo from '../../repos/UsersRepo';
 import LecturesRepo from '../../repos/LecturesRepo';
 import LectureManager from '../../LectureManager';
 
-class GetLiveLecturesRouter extends AppDevRouter {
+class GetLiveLecturesRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.GET);
   }

--- a/src/routers/Lectures/LecturePortsRouter.js
+++ b/src/routers/Lectures/LecturePortsRouter.js
@@ -10,7 +10,7 @@ import constants from '../../utils/constants';
  * though this is till tbd.
  * ask @mrkev for more info.
  */
-class LecturePortsRouter extends AppDevRouter {
+class LecturePortsRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.GET);
   }

--- a/src/routers/Lectures/PostLectureRouter.js
+++ b/src/routers/Lectures/PostLectureRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import LecturesRepo from '../../repos/LecturesRepo';
 import constants from '../../utils/constants';
 
-class PostLectureRouter extends AppDevRouter {
+class PostLectureRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/Lectures/UpdateLectureRouter.js
+++ b/src/routers/Lectures/UpdateLectureRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import LecturesRepo from '../../repos/LecturesRepo';
 import constants from '../../utils/constants';
 
-class UpdateLectureRouter extends AppDevRouter {
+class UpdateLectureRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.PUT);
   }

--- a/src/routers/Organizaitons/DeleteOrganizationRouter.js
+++ b/src/routers/Organizaitons/DeleteOrganizationRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import OrganizationsRepo from '../../repos/OrganizationsRepo';
 import constants from '../../utils/constants';
 
-class DeleteOrganizationRouter extends AppDevRouter {
+class DeleteOrganizationRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.DELETE);
   }

--- a/src/routers/Organizaitons/PostOrganizationRouter.js
+++ b/src/routers/Organizaitons/PostOrganizationRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import OrganizationsRepo from '../../repos/OrganizationsRepo';
 import constants from '../../utils/constants';
 
-class PostOrganizationRouter extends AppDevRouter {
+class PostOrganizationRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/Organizaitons/UpdateOrganizationRouter.js
+++ b/src/routers/Organizaitons/UpdateOrganizationRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import OrganizationsRepo from '../../repos/OrganizationsRepo';
 import constants from '../../utils/constants';
 
-class UpdateOrganizationRouter extends AppDevRouter {
+class UpdateOrganizationRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.PUT);
   }

--- a/src/routers/Questions/DeleteQuestionRouter.js
+++ b/src/routers/Questions/DeleteQuestionRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import QuestionsRepo from '../../repos/QuestionsRepo';
 import constants from '../../utils/constants';
 
-class DeleteQuestionRouter extends AppDevRouter {
+class DeleteQuestionRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.DELETE);
   }

--- a/src/routers/Questions/PostQuestionRouter.js
+++ b/src/routers/Questions/PostQuestionRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import QuestionsRepo from '../../repos/QuestionsRepo';
 import constants from '../../utils/constants';
 
-class PostQuestionRouter extends AppDevRouter {
+class PostQuestionRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/Questions/UpdateQuestionRouter.js
+++ b/src/routers/Questions/UpdateQuestionRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import QuestionsRepo from '../../repos/QuestionsRepo';
 import constants from '../../utils/constants';
 
-class UpdateQuestionRouter extends AppDevRouter {
+class UpdateQuestionRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.PUT);
   }

--- a/src/routers/Responses/PostResponseRouter.js
+++ b/src/routers/Responses/PostResponseRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import ResponsesRepo from '../../repos/ResponsesRepo';
 import constants from '../../utils/constants';
 
-class PostResponseRouter extends AppDevRouter {
+class PostResponseRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/StartLectureRouter.js
+++ b/src/routers/StartLectureRouter.js
@@ -6,7 +6,7 @@ import LecturesRepo from '../repos/LecturesRepo';
 import {Request} from 'express';
 import socket from 'socket.io';
 
-class StartLectureRouter extends AppDevRouter {
+class StartLectureRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.POST);
   }

--- a/src/routers/Users/GetUserCoursesRouter.js
+++ b/src/routers/Users/GetUserCoursesRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import UsersRepo from '../../repos/UsersRepo';
 import constants from '../../utils/constants';
 
-class GetUserCoursesRouter extends AppDevRouter {
+class GetUserCoursesRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.GET);
   }
@@ -24,8 +24,8 @@ class GetUserCoursesRouter extends AppDevRouter {
         node: {
           id: course.id,
           name: course.name,
-          term: course.term,
-        },
+          term: course.term
+        }
       }));
   }
 }

--- a/src/routers/Users/GetUsersRouter.js
+++ b/src/routers/Users/GetUsersRouter.js
@@ -4,7 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import UsersRepo from '../../repos/UsersRepo';
 import constants from '../../utils/constants';
 
-class GetUsersRouter extends AppDevRouter {
+class GetUsersRouter extends AppDevRouter<Object> {
   constructor () {
     super(constants.REQUEST_TYPES.GET);
   }

--- a/src/utils/AppDevEdgeRouter.js
+++ b/src/utils/AppDevEdgeRouter.js
@@ -24,7 +24,7 @@ export type AppDevEdgesResponse<T> = {
 
 type ErrorCollector = Error => void
 
-class AppDevEdgeRouter<T> extends AppDevRouter {
+class AppDevEdgeRouter<T> extends AppDevRouter<AppDevEdgesResponse<T>> {
   defaultCount () {
     return 10;
   }

--- a/src/utils/AppDevNodeRouter.js
+++ b/src/utils/AppDevNodeRouter.js
@@ -10,7 +10,7 @@ export type AppDevNodeResponse<T> = { node: T }
  * For fetching nodes.
  * NOTE: Expects the path to contain an :id field!
  */
-class AppDevNodeRouter<T> extends AppDevRouter {
+class AppDevNodeRouter<T> extends AppDevRouter<AppDevNodeResponse<T>> {
   constructor () {
     super('GET');
   }

--- a/src/utils/AppDevRouter.js
+++ b/src/utils/AppDevRouter.js
@@ -13,17 +13,20 @@ import {
 
 import constants from './constants';
 
-class AppDevResponse {
+class AppDevResponse<T> {
   success: boolean;
-  data: Object;
+  data: T;
 
-  constructor (success: boolean, data: Object) {
+  constructor (success: boolean, data: T) {
     this.success = success;
     this.data = data;
   }
 }
 
-class AppDevRouter {
+/**
+ * T is the response type for AppDevRouter
+ */
+export default class AppDevRouter<T: Object> {
   router: Router;
   requestType: RequestType;
 
@@ -70,7 +73,7 @@ class AppDevRouter {
 
   response = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const content = await this.content(req);
+      const content: T = await this.content(req);
       res.json(new AppDevResponse(true, content));
     } catch (e) {
       if (e.message === 1) {
@@ -85,5 +88,3 @@ class AppDevRouter {
     throw new Error(1);
   }
 }
-
-export default AppDevRouter;


### PR DESCRIPTION
`AppDevEdgeRouter<T>` and `AppDevNodeRouter<T>` are safer because parameter `T` specifies what the router is gonna return, so when a developer extends the class the content-producing method returns the right type of content.

`AppDevRouter` doesn't do this, and so whomever extends it can return whatever they want in when they implement `content() { ... }` and can change it without signaling anywhere that there was a type change. This is very much non-ideal.

Requiring type parameters  is a common pattern, and a good one. `React.Component` has required parameters `<Props, State>` for example, to enforce type safety on the components properties and state respectively. Generally, one should try to avoid undefined, hand-wavy types.


NOTE: this is a large PR because it makes all routers return `AppDevRouter<Object>` so the code still compiles. These should be changed in due time to `AppDevRouter<C>` for some other type `C` that's more specific to the response type of the router. All new routers should specify a type other than `Object` as `C`.


